### PR TITLE
Fix the uninitialized problem of stack pointer

### DIFF
--- a/emu-rv32i.c
+++ b/emu-rv32i.c
@@ -2144,6 +2144,8 @@ int main(int argc, char** argv)
 
     /* run program in emulator */
     pc = ram_start;
+    /* Initialize the address of stack pointer*/
+    reg[2] = ram_start + RAM_SIZE - 4;
     riscv_cpu_interp_x32();
 
     uint64_t ns2 = get_clock();


### PR DESCRIPTION
When executing the `sw` instruction, it will violate the maximum RAM_SIZE.