### PR TITLE
Support glibc compiled static ELF

### DIFF
--- a/emu-rv32i.c
+++ b/emu-rv32i.c
@@ -2053,7 +2053,7 @@ int main(int argc, char** argv)
         }
     }
 
-    /* set .text segment as the base address */
+    /* set .text section as the base address */
     scn = NULL;
     size_t shstrndx;
     elf_getshdrstrndx(elf, &shstrndx);
@@ -2081,7 +2081,7 @@ int main(int argc, char** argv)
     while ((scn = elf_nextscn(elf, scn)) != NULL) {
         gelf_getshdr(scn, &shdr);
 
-        /* filter NULL address segments and .bss */
+        /* filter NULL address sections and .bss */
         if (shdr.sh_addr && shdr.sh_type != SHT_NOBITS) {
             Elf_Data *data = elf_getdata(scn, NULL);
             if (shdr.sh_addr >= ram_start) {

--- a/emu-rv32i.c
+++ b/emu-rv32i.c
@@ -2080,7 +2080,9 @@ int main(int argc, char** argv)
     scn = NULL;
     while ((scn = elf_nextscn(elf, scn)) != NULL) {
         gelf_getshdr(scn, &shdr);
-        if (shdr.sh_type == SHT_PROGBITS) {
+
+        /* filter NULL address segments and .bss */
+        if (shdr.sh_addr && shdr.sh_type != SHT_NOBITS) {
             Elf_Data *data = elf_getdata(scn, NULL);
             if (shdr.sh_addr >= ram_start) {
                 for (size_t i = 0; i < shdr.sh_size; i++) {


### PR DESCRIPTION
Glibc runtime use .init_array and .fini_array (which is not loaded by emulator) to do initialization and finalization.
I add a quick fix so it now load every section from binary except NULL address section and `.bss`. Since `ram` lives in emulator's `.bss` section, emulator don't have to zero out the memory while loading `.bss` section.