### PR TITLE
Makefile: add -std=gnu99 to prevent errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINS = emu-rv32i test1
 CROSS_COMPILE = riscv-none-embed-
 RV32I_CFLAGS = -march=rv32i -mabi=ilp32 -O3 -nostdlib
 
-CFLAGS = -O3 -Wall
+CFLAGS = -O3 -Wall -std=gnu99
 LDFLAGS = -lelf
 
 all: $(BINS)


### PR DESCRIPTION
Such as: emu-rv32i.c:1922:5: error: ‘for’ loop initial declarations are only allowed in C99 mode