### PR TITLE
Modify `target_write_u32()` to make 32-bit data output easier

### DIFF
--- a/emu-rv32i.c
+++ b/emu-rv32i.c
@@ -878,6 +878,7 @@ int target_write_u32(uint32_t addr, uint32_t val)
         return 1;
     }
     if (addr == MTIMECMP_ADDR) {
+        printf("%d", val);
         mtimecmp = (mtimecmp & 0xffffffff00000000ll) | val;
         mip &= ~MIP_MTIP;
     } else if (addr == MTIMECMP_ADDR + 4) {


### PR DESCRIPTION
* Modify `target_write_u32()` function to make 32-bit data output easier
    * User can now output integer or any data type in 32-bit by assigning to `(volatile <type> *)0x40000008`